### PR TITLE
Inclusion of heat pump in scenario manager

### DIFF
--- a/code_examples/rts_0_config.yaml
+++ b/code_examples/rts_0_config.yaml
@@ -285,8 +285,13 @@ prosumer:
                                             #   "water" - water-water heat pump
                                             # each prosumer selects a random value off this list
 
-  "hp_storage": [2, 3]                      # storage capacity in hours of installed heat pump capacity
-                                            # note: heat pump capacity is ceiled maximum heating demand of household
+  hp_temperature: 35                        # supply temperature of the heating system
+                                            # needs to match value in heat pump specification file
+
+  "hp_capacity": [2, 3]                     # storage capacity in hours of installed heat pump capacity in hours of
+                                            # maximum power, which is the ceiled maximum heat demand from file
+
+  "hp_soc_init": 0.1                       # initial soc of the storage (0-1)
 
   "hp_fcast": "nn"                          # heating demand forecasting technique
                                             #   "nn" - neural network based on the included weather data

--- a/code_examples/rts_0_config.yaml
+++ b/code_examples/rts_0_config.yaml
@@ -279,6 +279,15 @@ prosumer:
 
   "hp_fraction": 0                          # fraction of prosumers with heat pumps
 
+  "hp_type": ["ground", "air", "air"]       # type of heat pump
+                                            #   "ground" - ground-water heat pump
+                                            #   "air" - air-water heat pump
+                                            #   "water" - water-water heat pump
+                                            # each prosumer selects a random value off this list
+
+  "hp_storage": [2, 3]                      # storage capacity in hours of installed heat pump capacity
+                                            # note: heat pump capacity is ceiled maximum heating demand of household
+
   "hp_fcast": "nn"                          # heating demand forecasting technique
                                             #   "nn" - neural network based on the included weather data
 

--- a/code_examples/sim_0_config.yaml
+++ b/code_examples/sim_0_config.yaml
@@ -285,6 +285,9 @@ prosumer:
                                             #   "water" - water-water heat pump
                                             # each prosumer selects a random value off this list
 
+  hp_temperature: 35                        # supply temperature of the heating system
+                                            # needs to match value in heat pump specification file
+
   "hp_capacity": [2, 3]                     # storage capacity in hours of installed heat pump capacity in hours of
                                             # maximum power, which is the ceiled maximum heat demand from file
 

--- a/code_examples/sim_0_config.yaml
+++ b/code_examples/sim_0_config.yaml
@@ -277,7 +277,7 @@ prosumer:
   ################################ heat pump settings ####################################
   ################################ heat pumps are coming soon
 
-  "hp_fraction": 0                          # fraction of prosumers with heat pumps
+  "hp_fraction": 1                          # fraction of prosumers with heat pumps
 
   "hp_type": ["ground", "air", "air"]       # type of heat pump
                                             #   "ground" - ground-water heat pump
@@ -291,10 +291,11 @@ prosumer:
   "hp_capacity": [2, 3]                     # storage capacity in hours of installed heat pump capacity in hours of
                                             # maximum power, which is the ceiled maximum heat demand from file
 
-  "hp_soc_init": 0.1                       # initial soc of the storage (0-1)
+  "hp_soc_init": 0.1                        # initial soc of the storage (0-1)
 
   "hp_fcast": "nn"                          # heating demand forecasting technique
                                             #   "nn" - neural network based on the included weather data
+                                            #   "mr" - multiple regression based on the included weather data
 
   ################################ electric vehicle settings ####################################
 

--- a/code_examples/sim_0_config.yaml
+++ b/code_examples/sim_0_config.yaml
@@ -285,8 +285,10 @@ prosumer:
                                             #   "water" - water-water heat pump
                                             # each prosumer selects a random value off this list
 
-  "hp_storage": [2, 3]                      # storage capacity in hours of installed heat pump capacity
-                                            # note: heat pump capacity is ceiled maximum heating demand of household
+  "hp_capacity": [2, 3]                     # storage capacity in hours of installed heat pump capacity in hours of
+                                            # maximum power, which is the ceiled maximum heat demand from file
+
+  "hp_soc_init": 0.1                       # initial soc of the storage (0-1)
 
   "hp_fcast": "nn"                          # heating demand forecasting technique
                                             #   "nn" - neural network based on the included weather data

--- a/code_examples/sim_0_config.yaml
+++ b/code_examples/sim_0_config.yaml
@@ -279,6 +279,15 @@ prosumer:
 
   "hp_fraction": 0                          # fraction of prosumers with heat pumps
 
+  "hp_type": ["ground", "air", "air"]       # type of heat pump
+                                            #   "ground" - ground-water heat pump
+                                            #   "air" - air-water heat pump
+                                            #   "water" - water-water heat pump
+                                            # each prosumer selects a random value off this list
+
+  "hp_storage": [2, 3]                      # storage capacity in hours of installed heat pump capacity
+                                            # note: heat pump capacity is ceiled maximum heating demand of household
+
   "hp_fcast": "nn"                          # heating demand forecasting technique
                                             #   "nn" - neural network based on the included weather data
 

--- a/input_data/prosumers/hp/hp_NIBE-F1245-12_ground.json
+++ b/input_data/prosumers/hp/hp_NIBE-F1245-12_ground.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Based on NIBE F1245-12 (12 kW) (p. 78). Value for cop_w55 guessed. Ground systems are independent of ambient temperatures.",
+  "ambient_temp": [-25, 15],
+  "cop_w35": [4.57, 4.57],
+  "cop_w45": [3.64, 3.64],
+  "cop_w55": [2.90, 2.90],
+  "link": "https://www.aircon.panasonic.eu/DE_de/ranges/aquarea/high-performance/"
+}

--- a/input_data/prosumers/hp/hp_NIBE-F2120-12_air.json
+++ b/input_data/prosumers/hp/hp_NIBE-F2120-12_air.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Based on NIBE F2120-12 (12 kW) (read from graph on p. 20)",
+  "ambient_temp": [-25, -15, -7, 2, 7, 15],
+  "cop_w35": [2.15, 2.80, 3.30, 4.10, 4.90, 6.05],
+  "cop_w45": [1.80, 2.30, 2.85, 3.50, 4.05, 4.85],
+  "cop_w55": [1.70, 2.00, 2.30, 2.95, 3.20, 3.95],
+  "link": "https://www.aircon.panasonic.eu/DE_de/ranges/aquarea/high-performance/"
+}

--- a/input_data/prosumers/hp/hp_Panasonic-Aquarea-LT-WH-MDC09J3E5_air.json
+++ b/input_data/prosumers/hp/hp_Panasonic-Aquarea-LT-WH-MDC09J3E5_air.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Based on Panasonic Aquarea LT WH-MDC09J3E5 (9 kW)",
+  "ambient_temp": [-7, 2, 7],
+  "cop_w35": [2.63, 3.13, 4.48],
+  "cop_w55": [1.80, 2.12, 2.78],
+  "link": "https://www.aircon.panasonic.eu/DE_de/ranges/aquarea/high-performance/"
+}

--- a/input_data/prosumers/hp/hp_Stiebel-Eltron-WPW-I-12-H-400 Premium_water.json
+++ b/input_data/prosumers/hp/hp_Stiebel-Eltron-WPW-I-12-H-400 Premium_water.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Based on Stiebel Eltron WPW-I 12 H 400 Premium (12 kW). Value for cop_w45 and cop_w55 guessed. Water systems are independent of ambient temperatures.",
+  "ambient_temp": [-25, 15],
+  "cop_w35": [5.80, 5.80],
+  "cop_w45": [4.90, 4.90],
+  "cop_w55": [4.00, 4.00],
+  "link": "https://www.aircon.panasonic.eu/DE_de/ranges/aquarea/high-performance/"
+}

--- a/lemlab/scenario_manager.py
+++ b/lemlab/scenario_manager.py
@@ -669,6 +669,7 @@ class Scenario:
         dict_hp = {"type": "hp",
                    "has_submeter": True,
                    "hp_type": choice(self.config["prosumer"]["hp_type"]),
+                   "temperature": self.config["prosumer"]["hp_temperature"],
                    "power": 0,
                    "capacity": choice(self.config["prosumer"]["hp_capacity"]),
                    "fcast": self.config["prosumer"]["hp_fcast"],

--- a/lemlab/scenario_manager.py
+++ b/lemlab/scenario_manager.py
@@ -14,6 +14,7 @@ from ruamel.yaml import YAML
 from typing import Tuple
 import pandas as pd
 import feather as ft
+import math
 
 
 class Scenario:
@@ -580,7 +581,7 @@ class Scenario:
             raise Warning(f"The value of participant_type '{participant_type}' does not exist.")
 
         # Update the dict and append the PV specifications to the list of plant specs
-        dict_pv.update({"power": pv_power,
+        dict_pv.update({"power": round(pv_power),
                         "controllable": self.config[participant_type]["pv_controllable"],
                         "fcast": self.config[participant_type]["pv_fcast"],
                         "fcast_order": [],
@@ -610,13 +611,13 @@ class Scenario:
         # Check if prosumer has PV system otherwise size according to household consumption
         pv_power = next((item["power"] for item in list_plant_specs if item["type"] == "pv"), None)
         if pv_power:
-            dict_bat["power"] = round(self.config["prosumer"]["bat_sizing_power"] * pv_power, 1)
+            dict_bat["power"] = round(self.config["prosumer"]["bat_sizing_power"] * pv_power)
         else:
             hh_consumption = next(item["annual_consumption"] for item in list_plant_specs if item["type"] == "hh")
-            dict_bat["power"] = round(self.config["prosumer"]["bat_sizing_power"] * hh_consumption, 1)
+            dict_bat["power"] = round(self.config["prosumer"]["bat_sizing_power"] * hh_consumption)
 
         # Update the dict and append the battery specifications to the list of plant specs
-        dict_bat.update({"capacity": dict_bat["power"] * self.config["prosumer"]["bat_sizing_capacity"],
+        dict_bat.update({"capacity": round(dict_bat["power"] * self.config["prosumer"]["bat_sizing_capacity"]),
                          "efficiency": self.config["prosumer"]["bat_efficiency"],
                          "charge_from_grid": self.config["prosumer"]["bat_charge_from_grid"],
                          "quality": self.config["prosumer"]["bat_quality"],
@@ -668,7 +669,8 @@ class Scenario:
         dict_hp = {"type": "hp",
                    "has_submeter": True,
                    "hp_type": choice(self.config["prosumer"]["hp_type"]),
-                   "storage": choice(self.config["prosumer"]["hp_storage"]) * 3600,
+                   "power": 0,
+                   "capacity": choice(self.config["prosumer"]["hp_capacity"]),
                    "fcast": self.config["prosumer"]["hp_fcast"],
                    "fcast_order": [],
                    "fcast_param": [],
@@ -975,8 +977,8 @@ class Scenario:
         plant_id = kwargs["plant_id"]
         plant_dict = kwargs["plant_dict"]
 
-        # Calculate absolute initial battery SoC in kWh
-        soc_init = plant_dict[plant_id].get('capacity') * self.config["prosumer"]["bat_soc_init"]
+        # Calculate absolute initial battery SoC in Wh
+        soc_init = round(plant_dict[plant_id].get('capacity') * self.config["prosumer"]["bat_soc_init"])
 
         # Write SoC to prosumer specifications directory
         with open(f"{self.path_scenario}/prosumer/{account['id_user']}/soc_{plant_id}.json", "w") \
@@ -1041,12 +1043,29 @@ class Scenario:
                            if str(annual_consumption) in household)
         filename_hh = f"{self.path_input_data}/prosumers/hh/{filename_hh}"
         # TODO: replace "power" column with "heat" column once it is implemented
-        df_heat = pd.read_csv(filename_hh, usecols=["timestamp", "power"]).set_index("timestamp") * (-1)
+        column = "power"
+        df_heat = pd.read_csv(filename_hh, usecols=["timestamp", column]).set_index("timestamp") * (-1)
+        df_heat.rename(columns={column: "heat"}, inplace=True)
+
+        # Update power and storage capacity information based on peak heat demand
+        max_heat = max(abs(df_heat["heat"]))
+        hp_power = math.ceil(max_heat / 10 ** (len(str(max_heat)) - 1)) * 10 ** (len(str(max_heat)) - 1)
+        hp_idx = next(idx for idx, plant in enumerate(account["list_plant_specs"]) if plant["type"] == "hp")
+        account["list_plant_specs"][hp_idx]["power"] = hp_power
+        account["list_plant_specs"][hp_idx]["capacity"] *= hp_power
+
+        # Calculate absolute initial battery SoC in Wh
+        soc_init = account["list_plant_specs"][hp_idx]["capacity"] * self.config["prosumer"]["hp_soc_init"]
 
         # Write heat demand time series to prosumer specifications directory
         ft.write_dataframe(df_heat.reset_index(),
                            f"{self.path_scenario}/prosumer/{account['id_user']}"
                            f"/raw_data_{plant_id}.ft")
+
+        # Write SoC to prosumer specifications directory
+        with open(f"{self.path_scenario}/prosumer/{account['id_user']}/soc_{plant_id}.json", "w") \
+                as write_file:
+            json.dump(soc_init, write_file)
 
         # Read random heat pump file that fits the heat pump type from input data directory and copy to
         # prosumer specifications directory

--- a/lemlab/scenario_manager.py
+++ b/lemlab/scenario_manager.py
@@ -1031,8 +1031,6 @@ class Scenario:
         # Read necessary keyword arguments
         account = kwargs["account"]
         plant_id = kwargs["plant_id"]
-        print(account)
-        exit()
 
         # Find out the annual consumption to identify the correct household heat demand time series
         hh_plant = next(plant for plant in account["list_plant_specs"] if plant["type"] == "hh")


### PR DESCRIPTION
Addresses #30

Heat pump can now be added to a prosumer via the config file. Four example heat pump files were added.

The config file was extended by two parameters:
hp_type: randomly choose type of heat pump from list
storage: randomly choose storage value from list

NOTE!!!: As heat demand is currently not available in the hh demand files it currently uses the power demand time series to be operational. Swap with heat demand as soon as it is implemented in lemlab.