### PR TITLE
Ticket #32: scenario_manager: introduce forecast training times to config file

### DIFF
--- a/code_examples/rts_0_config.yaml
+++ b/code_examples/rts_0_config.yaml
@@ -502,6 +502,13 @@ aggregator:
                                             #       the last 2 days
                                             #     "sarma"   - full sarma model of order below
 
+  "fcast_retraining_period": 86400          # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "fcast_update_period": 3600               # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
+
                                             # order of double seasonal arma model
   "fcast_sarma_order": [2, 0, 2,            # [ar,    0, ma,
                         2, 0, 0, 96,        #  s1_ar, 0, s1_ma, s1,

--- a/code_examples/rts_0_config.yaml
+++ b/code_examples/rts_0_config.yaml
@@ -211,6 +211,13 @@ prosumer:
                            2, 0, 0, 96,     #  s1_ar, 0, s1_ma, s1,
                            2, 0, 0, 672]    #  s2_ar, 0, s2_ma, s2]
 
+  "hh_fcast_retraining_period": 3600        # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "hh_fcast_update_period": 3600            # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
+
   ################################ small-scale photovoltaic settings ####################################
 
   "pv_fraction": 0.7                        # fraction of prosumers with pv plants
@@ -227,6 +234,13 @@ prosumer:
                                             #   "smoothed" - prediction value is a moving mean of the future values.
                                             #                window width of 9 time steps
                                             #   "pv_file_fcast_nn" - forecast based on weather fcast file (coming soon)
+
+  "pv_fcast_retraining_period": 86400       # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "pv_fcast_update_period": 3600            # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
 
   "pv_quality": "green_local"               # quality that the generated energy should be labelled with on the lem
 
@@ -247,6 +261,13 @@ prosumer:
                                             #                           and turbine model
                                             #   "wind_lookup_file_fcast" - weather forecast from file used with
                                             #                              turbine model
+
+  "wind_fcast_retraining_period": 86400     # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "wind_fcast_update_period": 3600          # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
 
   "wind_quality": "green_local"             # quality that the generated energy should be labelled with on the lem
 
@@ -281,6 +302,13 @@ prosumer:
 
   "hp_fcast": "nn"                          # heating demand forecasting technique
                                             #   "nn" - neural network based on the included weather data
+
+  "hp_fcast_retraining_period": 86400       # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "hp_fcast_update_period": 3600            # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
 
   ################################ electric vehicle settings ####################################
 
@@ -325,6 +353,13 @@ prosumer:
   "mpc_price_fcast": "naive"                # forecast model to be used for the lem market price
                                             #     "flat" - no meaningful forecasting, flat price assumed
                                             #     "naive" - expected price same as previous day (initialized flat)
+
+  "mpc_price_fcast_retraining_period": 86400 # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "mpc_price_fcast_update_period": 3600     # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
 
   "mpc_horizon": 96                         # mpc horizon : 1 - 96   -> unit steps (15 min)
 
@@ -383,6 +418,13 @@ producer:
                                             #                window width of 9 time steps
                                             #   "file_nn" - forecast based on weather forecast file (coming soon)
 
+  "pv_fcast_retraining_period": 86400       # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "pv_fcast_update_period": 3600            # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
+
   "pv_quality": "green_local"               # quality that the generated energy should be labelled with on the lem
 
   ################################ large-scale wind generation settings ####################################
@@ -399,6 +441,13 @@ producer:
                                             #                           and turbine model
                                             #   "wind_lookup_file_forecast" - weather forecast from file used with
                                             #                                 turbine model
+
+  "mpc_price_fcast_retraining_period": 86400 # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "mpc_price_fcast_update_period": 3600     # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
 
   "wind_quality": "green_local"             # quality that the generated energy should be labelled with on the lem
 

--- a/code_examples/sim_0_config.yaml
+++ b/code_examples/sim_0_config.yaml
@@ -196,7 +196,7 @@ prosumer:
                                             #         hh_intervals:     [2000, 4000]
                                             #         --> 20% <=2000, 2000< 60% <=4000, 20% >4000
 
-  "hh_fcast": "naive_average"               # household load forecasting method
+  "hh_fcast": "smoothed"               # household load forecasting method
                                             #   "perfect" - perfect knowledge of the future
                                             #   "naive"   - today will be the same as yesterday
                                             #   "naive_average" - today will be the same as
@@ -210,6 +210,13 @@ prosumer:
   "hh_fcast_sarma_order": [2, 0, 2,         # [ar,    0, ma,
                            2, 0, 0, 96,     #  s1_ar, 0, s1_ma, s1,
                            2, 0, 0, 672]    #  s2_ar, 0, s2_ma, s2]
+
+  "hh_fcast_retraining_period": 3600        # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "hh_fcast_update_period": 3600            # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
 
   ################################ small-scale photovoltaic settings ####################################
 
@@ -227,6 +234,13 @@ prosumer:
                                             #   "smoothed" - prediction value is a moving mean of the future values.
                                             #                window width of 9 time steps
                                             #   "pv_file_fcast_nn" - forecast based on weather fcast file (coming soon)
+
+  "pv_fcast_retraining_period": 86400       # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "pv_fcast_update_period": 3600            # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
 
   "pv_quality": "green_local"               # quality that the generated energy should be labelled with on the lem
 
@@ -247,6 +261,13 @@ prosumer:
                                             #                           and turbine model
                                             #   "wind_lookup_file_fcast" - weather forecast from file used with
                                             #                              turbine model
+
+  "wind_fcast_retraining_period": 86400     # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "wind_fcast_update_period": 3600          # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
 
   "wind_quality": "green_local"             # quality that the generated energy should be labelled with on the lem
 
@@ -281,6 +302,13 @@ prosumer:
 
   "hp_fcast": "nn"                          # heating demand forecasting technique
                                             #   "nn" - neural network based on the included weather data
+
+  "hp_fcast_retraining_period": 86400       # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "hp_fcast_update_period": 3600            # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
 
   ################################ electric vehicle settings ####################################
 
@@ -325,6 +353,13 @@ prosumer:
   "mpc_price_fcast": "naive"                # forecast model to be used for the lem market price
                                             #     "flat" - no meaningful forecasting, flat price assumed
                                             #     "naive" - expected price same as previous day (initialized flat)
+
+  "mpc_price_fcast_retraining_period": 86400 # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "mpc_price_fcast_update_period": 3600     # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
 
   "mpc_horizon": 96                         # mpc horizon : 1 - 96   -> unit steps (15 min)
 
@@ -383,6 +418,13 @@ producer:
                                             #                window width of 9 time steps
                                             #   "file_nn" - forecast based on weather forecast file (coming soon)
 
+  "pv_fcast_retraining_period": 86400       # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "pv_fcast_update_period": 3600            # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
+
   "pv_quality": "green_local"               # quality that the generated energy should be labelled with on the lem
 
   ################################ large-scale wind generation settings ####################################
@@ -399,6 +441,13 @@ producer:
                                             #                           and turbine model
                                             #   "wind_lookup_file_forecast" - weather forecast from file used with
                                             #                                 turbine model
+
+  "wind_fcast_retraining_period": 86400     # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "wind_fcast_update_period": 3600          # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
 
   "wind_quality": "green_local"             # quality that the generated energy should be labelled with on the lem
 

--- a/code_examples/sim_0_config.yaml
+++ b/code_examples/sim_0_config.yaml
@@ -502,6 +502,13 @@ aggregator:
                                             #       the last 2 days
                                             #     "sarma"   - full sarma model of order below
 
+  "fcast_retraining_period": 86400          # models should be periodically retrained based on new data
+                                            # how many seconds between retraining periods?
+
+  "fcast_update_period": 3600               # forecasts are periodically updated and saved to file where the
+                                            # most current forecast can be retrieved by model predictive controllers
+                                            # and market agents. How many seconds between updates?
+
                                             # order of double seasonal arma model
   "fcast_sarma_order": [2, 0, 2,            # [ar,    0, ma,
                         2, 0, 0, 96,        #  s1_ar, 0, s1_ma, s1,

--- a/code_examples/sim_0_config.yaml
+++ b/code_examples/sim_0_config.yaml
@@ -196,7 +196,7 @@ prosumer:
                                             #         hh_intervals:     [2000, 4000]
                                             #         --> 20% <=2000, 2000< 60% <=4000, 20% >4000
 
-  "hh_fcast": "smoothed"               # household load forecasting method
+  "hh_fcast": "naive_average"               # household load forecasting method
                                             #   "perfect" - perfect knowledge of the future
                                             #   "naive"   - today will be the same as yesterday
                                             #   "naive_average" - today will be the same as

--- a/lemlab/scenario_manager.py
+++ b/lemlab/scenario_manager.py
@@ -343,6 +343,8 @@ class Scenario:
         prosumer_info = {
             "mpc_horizon": self.config["prosumer"]["mpc_horizon"],
             "mpc_price_fcast": self.config["prosumer"]["mpc_price_fcast"],
+            "mpc_price_fcast_retraining_period": self.config["prosumer"]["mpc_price_fcast_retraining_period"],
+            "mpc_price_fcast_update_period": self.config["prosumer"]["mpc_price_fcast_update_period"],
             "solver": self.config["prosumer"]["general_solver"],
             "meter_prob_late": self.config["prosumer"]["meter_prob_late"],
             "meter_prob_late_95": self.config["prosumer"]["meter_prob_late_95"],
@@ -473,28 +475,20 @@ class Scenario:
         # Dict containing all specifications of the household
         dict_hh = {"type": "hh",
                    "has_submeter": self.config["prosumer"]["hh_has_submeter"],
+                   "fcast": self.config["prosumer"]["hh_fcast"],
+                   "fcast_order": [],
+                   "fcast_param": [],
+                   "fcast_retraining_period": self.config["prosumer"]["hh_fcast_retraining_period"],
+                   "fcast_update_period": self.config["prosumer"]["hh_fcast_update_period"],
                    }
 
-        # Add the corresponding forecast method to dict
-        if self.config["prosumer"]["hh_fcast"] == "sarma":
-            fcast_order = self.config["prosumer"]["hh_fcast_sarma_order"]
-            num_param = sum(fcast_order) - fcast_order[6] - fcast_order[10]
-            fcast_param = [1 / num_param] * num_param
-            params = {"fcast": "sarma",
-                      "fcast_order": fcast_order,
-                      "fcast_param": fcast_param,
-                      }
-        elif self.config["prosumer"]["hh_fcast"] == "smoothed":
-            params = {"fcast": self.config["prosumer"]["hh_fcast"],
-                      "fcast_order": [],
-                      "fcast_param": 9,
-                      }
-        else:
-            params = {"fcast": self.config["prosumer"]["hh_fcast"],
-                      "fcast_order": [],
-                      "fcast_param": [],
-                      }
-        dict_hh.update(params)
+        # Change the forecast parameters based on the method
+        if dict_hh["fcast"] == "sarma":
+            dict_hh["fcast_order"] = self.config["prosumer"]["hh_fcast_sarma_order"]
+            num_param = sum(dict_hh["fcast_order"]) - dict_hh["fcast_order"][6] - dict_hh["fcast_order"][10]
+            dict_hh["fcast_param"] = [1 / num_param] * num_param
+        elif dict_hh["fcast"] == "smoothed":
+            dict_hh["fcast_param"] = 9
 
         # Add the corresponding preliminary consumption to dict that is used for the dimensioning of pv, bat and hp
         if self.config["prosumer"]["hh_sizing"] == "uniform":
@@ -585,6 +579,8 @@ class Scenario:
                         "fcast": self.config[participant_type]["pv_fcast"],
                         "fcast_order": [],
                         "fcast_param": 9,
+                        "fcast_retraining_period": self.config["prosumer"]["pv_fcast_retraining_period"],
+                        "fcast_update_period": self.config["prosumer"]["pv_fcast_update_period"],
                         "quality": self.config[participant_type]["pv_quality"],
                         })
 
@@ -670,6 +666,8 @@ class Scenario:
                    "fcast": self.config["prosumer"]["hp_fcast"],
                    "fcast_order": [],
                    "fcast_param": [],
+                   "fcast_retraining_period": self.config["prosumer"]["pv_fcast_retraining_period"],
+                   "fcast_update_period": self.config["prosumer"]["pv_fcast_update_period"],
                    }
 
         list_plant_specs.append(dict_hp)
@@ -713,6 +711,8 @@ class Scenario:
                           "fcast": self.config[participant_type]["wind_fcast"],
                           "fcast_order": [],
                           "fcast_param": 9,
+                          "fcast_retraining_period": self.config["prosumer"]["pv_fcast_retraining_period"],
+                          "fcast_update_period": self.config["prosumer"]["pv_fcast_update_period"],
                           "quality": self.config[participant_type]["wind_quality"],
                           })
 


### PR DESCRIPTION
Adds the new forecast parameters to the prosumer files that are necessary for forecasting methods that retrain and update (neural networks).

The change takes the new parameters in the config file and save them in the corresponding dictionary json files of the prosumers, producers and aggregator.

**Files changed:**
- config files
- scenario_manager