### PR TITLE
Bugfix: Prosumer parameters missing 

### DIFF
--- a/lemlab/scenario_manager.py
+++ b/lemlab/scenario_manager.py
@@ -368,6 +368,8 @@ class Scenario:
                 "list_plant_specs": list_plant_specs,
                 "ma_horizon": choice(self.config["prosumer"]["ma_horizon"]),
                 "ma_strategy": choice(self.config["prosumer"]["ma_strategy"]),
+                "ma_bid_max": self.config["retailer"]["price_sell"],
+                "ma_offer_min":self.config["retailer"]["price_buy"],
                 "ma_preference_quality": choice(self.config["prosumer"]["ma_preference_quality"]),
                 "ma_premium_preference_quality": choice(self.config["prosumer"]["ma_premium_preference_quality"]),
             })
@@ -387,6 +389,8 @@ class Scenario:
                     "list_plant_specs": list_plant_specs,
                     "ma_horizon": choice(self.config["prosumer"]["ma_horizon"]),
                     "ma_strategy": choice(self.config["prosumer"]["ma_strategy"]),
+                    "ma_bid_max": self.config["retailer"]["price_sell"],
+                    "ma_offer_min":self.config["retailer"]["price_buy"],
                     "ma_preference_quality": choice(self.config["prosumer"]["ma_preference_quality"]),
                     "ma_premium_preference_quality": choice(self.config["prosumer"]["ma_premium_preference_quality"]),
                 })


### PR DESCRIPTION
The request adds the following parameters to the prosumers and producers account information:

- ma_bid_max
- ma_offer_min

The parameters are based on the min and max price values of the retailer.